### PR TITLE
Set default value for BasicType to UNDEFINED

### DIFF
--- a/bundle.proto
+++ b/bundle.proto
@@ -12,14 +12,17 @@ tensors.
 
 **************************************************/
 enum BasicType {
+  /* Default, unknown type */
+  UNDEFINED = 0;
+
   /* Fixed-width types */
-  BOOLEAN = 0;
-  BYTE = 1;
-  SHORT = 2;
-  INT = 3;
-  LONG = 4;
-  FLOAT = 5;
-  DOUBLE = 6;
+  BOOLEAN = 1;
+  BYTE = 2;
+  SHORT = 3;
+  INT = 4;
+  LONG = 5;
+  FLOAT = 6;
+  DOUBLE = 7;
 
   /* Variable-width types */
   STRING = 100;


### PR DESCRIPTION
Per protobuf best practices (here's an example of the problem: http://androiddevblog.com/protocol-buffers-pitfall-adding-enum-values/), you should never use '0' as a real value in your enums.  This would prevent you from being able to determine if the value is 'empty' or 'default', as the language generated code always uses the value at 0 as the default for the field.

This is causing problems in mleap for BasicType serialization in transformers.  If the type being serialized is `BasicType.BOOLEAN`, the code has no way to determine if the value has been set or is the default, which is causing mleap to skip serialization of the field.

A forthcoming related mleap PR will fix that issue as well.

Please note that this is entirely NOT backwards compatible.  It is, however, the correct solution in this scenario (in my opinion).