### PR TITLE
Add meta to Bundle message

### DIFF
--- a/bundle.proto
+++ b/bundle.proto
@@ -123,6 +123,7 @@ message Bundle {
   Format format = 3;
   string version = 4;
   string timestamp = 5;
+  Attributes meta = 6;
 }
 
 message Model {


### PR DESCRIPTION
This PR adds a `meta` field of type `Attributes` to the `Bundle` protobuf message.  More information on its expected use can be found on the relevant MLeap PR.